### PR TITLE
Fix Windows EOL in devdump.py

### DIFF
--- a/alex/devdump.py
+++ b/alex/devdump.py
@@ -87,7 +87,7 @@ def device_has_su() -> bool:
         return False
 
 def push_temp_script(script_text):
-    with tempfile.NamedTemporaryFile("w", delete=False) as f:
+    with tempfile.NamedTemporaryFile("w", delete=False, newline="\n") as f:
         f.write(script_text)
         local_path = f.name
     remote_path = "/data/local/tmp/devicedump.sh"


### PR DESCRIPTION
Explicitly set newline to be Unix EOL. This resolves the Issue reported at [https://github.com/prosch88/ALEX/issues/1](https://github.com/prosch88/ALEX/issues/1)

