### PR TITLE
fix: sanitize exotic Unicode chars in PDF report generation

### DIFF
--- a/alex.py
+++ b/alex.py
@@ -51,6 +51,55 @@ import typing
 import pathlib
 import re
 import io
+import unicodedata
+
+# Map of known problematic look-alike / exotic Unicode characters to safe PDF replacements
+_CHAR_REPLACEMENTS = {
+    '\uFE6B': '@',   # ﹫ SMALL COMMERCIAL AT
+    '\uFF20': '@',   # ＠ FULLWIDTH COMMERCIAL AT
+    '\uFE50': ',',   # ﹐ SMALL COMMA
+    '\uFE51': ',',   # ﹑ SMALL IDEOGRAPHIC COMMA
+    '\uFE52': '.',   # ﹒ SMALL FULL STOP
+    '\uFE54': ';',   # ﹔ SMALL SEMICOLON
+    '\uFE55': ':',   # ﹕ SMALL COLON
+    '\uFE56': '?',   # ﹖ SMALL QUESTION MARK
+    '\uFE57': '!',   # ﹗ SMALL EXCLAMATION MARK
+    '\uFE58': '-',   # ﹘ SMALL EM DASH
+    '\uFF01': '!',   # ！ FULLWIDTH EXCLAMATION MARK
+    '\uFF0C': ',',   # ， FULLWIDTH COMMA
+    '\uFF0E': '.',   # ． FULLWIDTH FULL STOP
+    '\uFF1A': ':',   # ： FULLWIDTH COLON
+    '\uFF1B': ';',   # ； FULLWIDTH SEMICOLON
+    '\uFF1F': '?',   # ？ FULLWIDTH QUESTION MARK
+    '\uFF3B': '[',   # ［ FULLWIDTH LEFT SQUARE BRACKET
+    '\uFF3D': ']',   # ］ FULLWIDTH RIGHT SQUARE BRACKET
+    '\uFF08': '(',   # （ FULLWIDTH LEFT PARENTHESIS
+    '\uFF09': ')',   # ） FULLWIDTH RIGHT PARENTHESIS
+    '\uFF0D': '-',   # － FULLWIDTH HYPHEN-MINUS
+    '\uFF3F': '_',   # ＿ FULLWIDTH LOW LINE
+    '\u2026': '...', # … HORIZONTAL ELLIPSIS
+    '\u2013': '-',   # – EN DASH
+    '\u2014': '-',   # — EM DASH
+    '\u2018': "'",   # ' LEFT SINGLE QUOTATION MARK
+    '\u2019': "'",   # ' RIGHT SINGLE QUOTATION MARK
+    '\u201C': '"',   # " LEFT DOUBLE QUOTATION MARK
+    '\u201D': '"',   # " RIGHT DOUBLE QUOTATION MARK
+}
+
+def sanitize_for_pdf(text) -> str:
+    """Replace characters unsupported by standard PDF fonts with safe ASCII equivalents."""
+    if not isinstance(text, str):
+        text = str(text) if text is not None else ""
+    result = []
+    for ch in text:
+        if ch in _CHAR_REPLACEMENTS:
+            result.append(_CHAR_REPLACEMENTS[ch])
+        elif ord(ch) > 0x017E and unicodedata.category(ch).startswith('C'):
+            # Drop control/format characters outside Latin Extended-B
+            pass
+        else:
+            result.append(ch)
+    return ''.join(result)
 
 ctk.set_appearance_mode("dark")  # Dark Mode
 ctk.set_default_color_theme(os.path.join(os.path.dirname(__file__), "assets" , "alex_theme.json" ))
@@ -2251,11 +2300,11 @@ class MyApp(ctk.CTk):
                             [
                                 {
                                     "style": {"cell_fill": row_bg}, 
-                                    ".": account.get("type")
+                                    ".": sanitize_for_pdf(account.get("type", ""))
                                 }, 
                                 {
                                     "style": {"cell_fill": row_bg}, 
-                                    ".": account.get("name")
+                                    ".": sanitize_for_pdf(account.get("name", ""))
                                 }
                             ]
                         ]
@@ -2276,9 +2325,9 @@ class MyApp(ctk.CTk):
                     },
                     "table": [
                         [
-                            {"style": {"cell_fill": row_bg}, ".": d_app[0]},
-                            {"style": {"cell_fill": row_bg}, ".": d_app[1]},
-                            {"style": {"cell_fill": row_bg}, ".": d_app[2]}
+                            {"style": {"cell_fill": row_bg}, ".": sanitize_for_pdf(d_app[0])},
+                            {"style": {"cell_fill": row_bg}, ".": sanitize_for_pdf(d_app[1])},
+                            {"style": {"cell_fill": row_bg}, ".": sanitize_for_pdf(d_app[2])}
                         ]
                     ]
                 }

--- a/alex.py
+++ b/alex.py
@@ -53,54 +53,6 @@ import re
 import io
 import unicodedata
 
-# Map of known problematic look-alike / exotic Unicode characters to safe PDF replacements
-_CHAR_REPLACEMENTS = {
-    '\uFE6B': '@',   # ﹫ SMALL COMMERCIAL AT
-    '\uFF20': '@',   # ＠ FULLWIDTH COMMERCIAL AT
-    '\uFE50': ',',   # ﹐ SMALL COMMA
-    '\uFE51': ',',   # ﹑ SMALL IDEOGRAPHIC COMMA
-    '\uFE52': '.',   # ﹒ SMALL FULL STOP
-    '\uFE54': ';',   # ﹔ SMALL SEMICOLON
-    '\uFE55': ':',   # ﹕ SMALL COLON
-    '\uFE56': '?',   # ﹖ SMALL QUESTION MARK
-    '\uFE57': '!',   # ﹗ SMALL EXCLAMATION MARK
-    '\uFE58': '-',   # ﹘ SMALL EM DASH
-    '\uFF01': '!',   # ！ FULLWIDTH EXCLAMATION MARK
-    '\uFF0C': ',',   # ， FULLWIDTH COMMA
-    '\uFF0E': '.',   # ． FULLWIDTH FULL STOP
-    '\uFF1A': ':',   # ： FULLWIDTH COLON
-    '\uFF1B': ';',   # ； FULLWIDTH SEMICOLON
-    '\uFF1F': '?',   # ？ FULLWIDTH QUESTION MARK
-    '\uFF3B': '[',   # ［ FULLWIDTH LEFT SQUARE BRACKET
-    '\uFF3D': ']',   # ］ FULLWIDTH RIGHT SQUARE BRACKET
-    '\uFF08': '(',   # （ FULLWIDTH LEFT PARENTHESIS
-    '\uFF09': ')',   # ） FULLWIDTH RIGHT PARENTHESIS
-    '\uFF0D': '-',   # － FULLWIDTH HYPHEN-MINUS
-    '\uFF3F': '_',   # ＿ FULLWIDTH LOW LINE
-    '\u2026': '...', # … HORIZONTAL ELLIPSIS
-    '\u2013': '-',   # – EN DASH
-    '\u2014': '-',   # — EM DASH
-    '\u2018': "'",   # ' LEFT SINGLE QUOTATION MARK
-    '\u2019': "'",   # ' RIGHT SINGLE QUOTATION MARK
-    '\u201C': '"',   # " LEFT DOUBLE QUOTATION MARK
-    '\u201D': '"',   # " RIGHT DOUBLE QUOTATION MARK
-}
-
-def sanitize_for_pdf(text) -> str:
-    """Replace characters unsupported by standard PDF fonts with safe ASCII equivalents."""
-    if not isinstance(text, str):
-        text = str(text) if text is not None else ""
-    result = []
-    for ch in text:
-        if ch in _CHAR_REPLACEMENTS:
-            result.append(_CHAR_REPLACEMENTS[ch])
-        elif ord(ch) > 0x017E and unicodedata.category(ch).startswith('C'):
-            # Drop control/format characters outside Latin Extended-B
-            pass
-        else:
-            result.append(ch)
-    return ''.join(result)
-
 ctk.set_appearance_mode("dark")  # Dark Mode
 ctk.set_default_color_theme(os.path.join(os.path.dirname(__file__), "assets" , "alex_theme.json" ))
 ctk.set_window_scaling(1.0)
@@ -4610,6 +4562,21 @@ def Popen(cmd, **kwargs):
 
     return subprocess.Popen(cmd, **kwargs)
 
+def sanitize_for_pdf(text) -> str:
+    """Replace characters unsupported by standard PDF fonts with safe ASCII equivalents."""
+    if not isinstance(text, str):
+        text = str(text) if text is not None else ""
+    result = []
+    for ch in text:
+        if ch in _CHAR_REPLACEMENTS:
+            result.append(_CHAR_REPLACEMENTS[ch])
+        elif ord(ch) > 0x017E and unicodedata.category(ch).startswith('C'):
+            # Drop control/format characters outside Latin Extended-B
+            pass
+        else:
+            result.append(ch)
+    return ''.join(result)
+
 device = None
 device_auto = None
 zytotal =0
@@ -4630,6 +4597,39 @@ case_name = ""
 evidence_number = ""
 examiner = ""
 device_info = ""
+
+# Map of known problematic look-alike / exotic Unicode characters to safe PDF replacements
+_CHAR_REPLACEMENTS = {
+    '\uFE6B': '@',   # ﹫ SMALL COMMERCIAL AT
+    '\uFF20': '@',   # ＠ FULLWIDTH COMMERCIAL AT
+    '\uFE50': ',',   # ﹐ SMALL COMMA
+    '\uFE51': ',',   # ﹑ SMALL IDEOGRAPHIC COMMA
+    '\uFE52': '.',   # ﹒ SMALL FULL STOP
+    '\uFE54': ';',   # ﹔ SMALL SEMICOLON
+    '\uFE55': ':',   # ﹕ SMALL COLON
+    '\uFE56': '?',   # ﹖ SMALL QUESTION MARK
+    '\uFE57': '!',   # ﹗ SMALL EXCLAMATION MARK
+    '\uFE58': '-',   # ﹘ SMALL EM DASH
+    '\uFF01': '!',   # ！ FULLWIDTH EXCLAMATION MARK
+    '\uFF0C': ',',   # ， FULLWIDTH COMMA
+    '\uFF0E': '.',   # ． FULLWIDTH FULL STOP
+    '\uFF1A': ':',   # ： FULLWIDTH COLON
+    '\uFF1B': ';',   # ； FULLWIDTH SEMICOLON
+    '\uFF1F': '?',   # ？ FULLWIDTH QUESTION MARK
+    '\uFF3B': '[',   # ［ FULLWIDTH LEFT SQUARE BRACKET
+    '\uFF3D': ']',   # ］ FULLWIDTH RIGHT SQUARE BRACKET
+    '\uFF08': '(',   # （ FULLWIDTH LEFT PARENTHESIS
+    '\uFF09': ')',   # ） FULLWIDTH RIGHT PARENTHESIS
+    '\uFF0D': '-',   # － FULLWIDTH HYPHEN-MINUS
+    '\uFF3F': '_',   # ＿ FULLWIDTH LOW LINE
+    '\u2026': '...', # … HORIZONTAL ELLIPSIS
+    '\u2013': '-',   # – EN DASH
+    '\u2014': '-',   # — EM DASH
+    '\u2018': "'",   # ' LEFT SINGLE QUOTATION MARK
+    '\u2019': "'",   # ' RIGHT SINGLE QUOTATION MARK
+    '\u201C': '"',   # " LEFT DOUBLE QUOTATION MARK
+    '\u201D': '"',   # " RIGHT DOUBLE QUOTATION MARK
+}
 
 # Problematic Characters for logs
 undict ={'â€¦': '…',"â€ž":"„" ,'â€“': '–', 'â€™': '’', "â€\x9d":"”",


### PR DESCRIPTION
pdfme's standard fonts do not contain glyphs for characters like ﹫ (U+FE6B SMALL COMMERCIAL AT), fullwidth punctuation, and similar Unicode variants. When account names or app info from the device contained these characters, build_pdf() crashed with a KeyError.

Added sanitize_for_pdf() helper that maps ~30 known problematic characters to safe ASCII equivalents and drops unsupported control characters before they reach pdfme.