### PR TITLE
fix: add utf-8 encoding to write_text calls in query_content

### DIFF
--- a/alex.py
+++ b/alex.py
@@ -3391,7 +3391,7 @@ def query_content(change, text, progress, prog_text, json_out=False, zip_path=No
             if json_out == False:
                 content_path = Path(f'{out}/{key}/{key}.txt')
                 content_path.parent.mkdir(parents=True, exist_ok=True)
-                content_path.write_text(content_out)
+                content_path.write_text(content_out, encoding="utf-8")
             else:
                 cjson = content_to_json(content_out)
                 json_out = json.dumps(cjson, ensure_ascii=False, indent=2)
@@ -3419,7 +3419,7 @@ def query_content(change, text, progress, prog_text, json_out=False, zip_path=No
                     if json_out == False:
                         content_path = Path(f'{out}/{key}/{key}_{item.replace("/","_")}.txt')
                         content_path.parent.mkdir(parents=True, exist_ok=True)
-                        content_path.write_text(content_out)
+                        content_path.write_text(content_out, encoding="utf-8")
                     else:
                         cjson = content_to_json(content_out)
                         json_out = json.dumps(cjson, ensure_ascii=False, indent=2)
@@ -3450,7 +3450,7 @@ def query_content(change, text, progress, prog_text, json_out=False, zip_path=No
                     if json_out == False:
                         content_path = Path(f'{out}/{key}/{key}_{value.replace("/","_")}.txt')
                         content_path.parent.mkdir(parents=True, exist_ok=True)
-                        content_path.write_text(content_out)
+                        content_path.write_text(content_out, encoding="utf-8")
                     else:
                         cjson = content_to_json(content_out)
                         json_out = json.dumps(cjson, ensure_ascii=False, indent=2)


### PR DESCRIPTION
Path.write_text() without an explicit encoding falls back to the system default. On Windows this is cp1252, which cannot encode emoji or most non-Latin characters found in device content provider data (e.g. U+1F643 caused a UnicodeEncodeError crash).

Added encoding='utf-8' to all three write_text(content_out) calls in query_content() at lines 3394, 3422 and 3453. The json_path write calls in the same function were already correct.